### PR TITLE
fix RELEASE variable if a RC

### DIFF
--- a/wordpress-jail.sh
+++ b/wordpress-jail.sh
@@ -60,7 +60,7 @@ fi
 . "${SCRIPTPATH}"/"${CONFIG_NAME}"
 INCLUDES_PATH="${SCRIPTPATH}"/includes
 
-RELEASE=$(freebsd-version | sed "s/STABLE/RELEASE/g" | sed "s/-p[0-9]*//")
+RELEASE=$(freebsd-version | cut -d - -f -1)"-RELEASE"
 
 #####################################################################
 print_msg "Input/Config Sanity checks..."


### PR DESCRIPTION
Freenas is currently on 12.2-RC3.  The current code to create the RELEASE variable doesn't work with it.